### PR TITLE
Fix calling updateDistance()

### DIFF
--- a/Measure.go
+++ b/Measure.go
@@ -165,6 +165,7 @@ findOuterMinDistanceFace:
 	measure.simplex = newSimplex
 	measure.updateSimplex()
 	measure.updateDirection()
+	measure.updateDistance()
 	measure.updateTheOthers()
 
 	measure.Distance *= -1.0

--- a/Measure_test.go
+++ b/Measure_test.go
@@ -191,10 +191,6 @@ func TestMeasureNonnegativeDistance_MinError(t *testing.T) {
 }
 
 func TestMeasureDistance(t *testing.T) {
-	if testing.Short() {
-		t.Skip("TODO: Make this test succeed.")
-	}
-
 	convexHull0 := []*mgl64.Vec3{
 		{0.0, 5.5, 0.0},
 		{2.3, 1.0, -2.0},
@@ -229,10 +225,6 @@ func TestMeasureDistance(t *testing.T) {
 }
 
 func TestMeasureDistance_Geodetic(t *testing.T) {
-	if testing.Short() {
-		t.Skip("TODO: Make this test succeed.")
-	}
-
 	convexHull0 := []*mgl64.Vec3{
 		{136.243592, 36.294155, 0},
 		{136.243591519521, 36.3058526069559, 0.132705141790211},


### PR DESCRIPTION
https://github.com/trajectoryjp/closest_go/releases/tag/v1.0.3 made MeasureNonnegativeDistance() precise, but TestMeasureDistance(\_) and TestMeasureDistance_Geodetic(\_) fail.
This is because I split updateDirection() into updateDirection() and updateDistance(), but did not add updateDistance() to epa().
Sorry, I fixed it.