### PR TITLE
Fix the error judgment and improve compatibility

### DIFF
--- a/Measure.go
+++ b/Measure.go
@@ -123,7 +123,7 @@ loop:
 		measure.updatePoints()
 		for i := 0; i < len(measure.Points); i += 1 {
 			for j := 0; j < 3; j += 1 {
-				if !(math.Abs(measure.Points[i][j]) < maxes[i][j]) { // For the case where points[i][j] == NaN
+				if !(math.Abs(measure.Points[i][j]) <= maxes[i][j]) { // For the case where points[i][j] == NaN
 					measure.simplex = lastSymplex.([]*vertex)
 					measure.Direction = lastDirection
 					measure.Points = lastPoints

--- a/Measure_test.go
+++ b/Measure_test.go
@@ -198,6 +198,23 @@ func TestMeasureNonnegativeDistance_MinError2(t *testing.T) {
 	)
 }
 
+func TestMeasureNonnegativeDistance_2Dimension(t *testing.T) {
+	testMeasureNonnegativeDistance(
+		t,
+		3.4704251289367676,
+		[]*mgl64.Vec3{
+			{10, 15, 0},
+			{93.76614808098593, 15, 0},
+		},
+		[]*mgl64.Vec3{
+			{26.902334690093994, 7.686383247375488, 0},
+			{30.745525360107422, 7.686383247375488, 0},
+			{30.745525360107422, 11.529574871063232, 0},
+			{26.902334690093994, 11.529574871063232, 0},
+		},
+	)
+}
+
 func testMeasureNonnegativeDistance(
 	t *testing.T,
 	correctDistance float64,

--- a/Measure_test.go
+++ b/Measure_test.go
@@ -238,7 +238,7 @@ func testMeasureNonnegativeDistance(
 func TestMeasureDistance(t *testing.T) {
 	testMeasureDistance(
 		t,
-		-0.2420013964014458,
+		-0.8135953914471573,
 		[]*mgl64.Vec3{
 			{0.0, 5.5, 0.0},
 			{2.3, 1.0, -2.0},
@@ -260,7 +260,7 @@ func TestMeasureDistance(t *testing.T) {
 func TestMeasureDistance_Geodetic(t *testing.T) {
 	testMeasureDistance(
 		t,
-		-4.071827329059758e-05,
+		-8.103902144849304e-05,
 		[]*mgl64.Vec3{
 			{136.243592, 36.294155, 0},
 			{136.243591519521, 36.3058526069559, 0.132705141790211},

--- a/Measure_test.go
+++ b/Measure_test.go
@@ -4,11 +4,18 @@ import (
 	"math/rand"
 	"time"
 
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+
 	"github.com/go-gl/mathgl/mgl64"
 	"github.com/xieyuschen/deepcopy"
 
 	"testing"
 )
+
+// option is required to compare floating-point values.
+// Removing this will cause tests on your machine or on GitHub Actions to fail.
+var option = cmpopts.EquateApprox(0, 1e-13)
 
 func TestMeasureNonnegativeDistance(t *testing.T) {
 	testMeasureNonnegativeDistance(
@@ -230,8 +237,10 @@ func testMeasureNonnegativeDistance(
 	start := time.Now()
 	measure.MeasureNonnegativeDistance()
 	t.Log("Time: ", time.Since(start))
-	if measure.Distance != correctDistance {
-		t.Error("The distance: ", measure.Distance, " is different from the correct distance: ", correctDistance)
+
+	difference := cmp.Diff(measure.Distance, correctDistance, option)
+	if difference != "" {
+		t.Error(difference)
 	}
 }
 
@@ -285,10 +294,6 @@ func TestMeasureDistance_Geodetic(t *testing.T) {
 }
 
 func TestMeasureDistance_Geodetic2(t *testing.T) {
-	if testing.Short() {
-		t.Skip("TODO: Make this test succeed.")
-	}
-
 	testMeasureDistance(
 		t,
 		5.7316269682416994e-05,
@@ -343,8 +348,9 @@ func TestMeasureDistance_DistanceNaN(t *testing.T) {
 	measure.MeasureDistance()
 	t.Log("Time: ", time.Since(start))
 
-	if measure.Distance != correctDistance {
-		t.Error("The distance: ", measure.Distance, " is different from the correct distance: ", correctDistance)
+	difference := cmp.Diff(measure.Distance, correctDistance, option)
+	if difference != "" {
+		t.Error(difference)
 	}
 }
 
@@ -364,8 +370,9 @@ func testMeasureDistance(
 	measure.MeasureDistance()
 	t.Log("Time: ", time.Since(start))
 
-	if measure.Distance != correctDistance {
-		t.Error("The distance: ", measure.Distance, " is different from the correct distance: ", correctDistance)
+	difference := cmp.Diff(measure.Distance, correctDistance, option)
+	if difference != "" {
+		t.Error(difference)
 	}
 }
 
@@ -421,7 +428,7 @@ func TestMeasureDistanceRandomly(t *testing.T) {
 		shiftedMeasure.MeasureDistance()
 		tryCount += 1
 
-		if shiftedMeasure.Distance < 0.0 {
+		if shiftedMeasure.Distance < 0.0 || !cmp.Equal(shiftedMeasure.Distance, 0.0, option) {
 			notCancelCount += 1
 		}
 		if shiftedMeasure.Distance >= minDistance {

--- a/go.mod
+++ b/go.mod
@@ -1,9 +1,10 @@
 module github.com/trajectoryjp/closest_go
 
-go 1.18
+go 1.21
 
 require (
 	github.com/go-gl/mathgl v1.1.0
+	github.com/google/go-cmp v0.7.0
 	github.com/xieyuschen/deepcopy v1.0.1
 )
 

--- a/go.sum
+++ b/go.sum
@@ -3,6 +3,8 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/go-gl/mathgl v1.1.0 h1:0lzZ+rntPX3/oGrDzYGdowSLC2ky8Osirvf5uAwfIEA=
 github.com/go-gl/mathgl v1.1.0/go.mod h1:yhpkQzEiH9yPyxDUGzkmgScbaBVlhC06qodikEM0ZwQ=
+github.com/google/go-cmp v0.7.0 h1:wk8382ETsv4JYUZwIsn6YpYiWiBsYLSJiTsyBybVuN8=
+github.com/google/go-cmp v0.7.0/go.mod h1:pXiqmnSA92OHEEa9HXL2W4E7lf9JzCmGVUdgjX3N/iU=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=


### PR DESCRIPTION
In v1.0.5, TestMeasureNonnegativeDistance_2Dimension failed, so the error judgment has been fixed.
The discovery of this issue was delayed due to test changes in v1.0.5.
To prevent recurrence, we now use [`cmpopts.Equateapprox`](https://github.com/google/go-cmp/blob/v0.7.0/cmp/cmpopts/equate.go#L50) to define the error due to differences in models.